### PR TITLE
update(hedgedoc): bump version to 1.9.9 (includes security fix)

### DIFF
--- a/roles/hedgedoc/defaults/main.yml
+++ b/roles/hedgedoc/defaults/main.yml
@@ -7,7 +7,7 @@ hedgedoc_db_database: "hedgedoc"
 hedgedoc_db_port: 5432
 hedgedoc_db_dialect: postgres
 
-hedgedoc_version: 1.9.6
+hedgedoc_version: 1.9.9
 
 hedgedoc_user: "hedgedoc"
 


### PR DESCRIPTION
see https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-7494-7hcf-vxpg