### PR TITLE
fix(vaultwarden): allow vaultwarden_container_labels to not be set

### DIFF
--- a/roles/vaultwarden/vars/main.yml
+++ b/roles/vaultwarden/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-vaultwarden_container_labels_merged: "{{ vaultwarden_container_labels_base | combine(vaultwarden_container_labels, recursive=True) }}"
+vaultwarden_container_labels_merged: "{{ vaultwarden_container_labels_base | combine(vaultwarden_container_labels | default({}), recursive=True) }}"
 vaultwarden_container_labels_base:
   version: "{{ vaultwarden_version }}"
 


### PR DESCRIPTION
Fixes:
```
TASK [famedly.services.vaultwarden : Ensure vaultwarden container image is running] ***********************************
fatal: [hostname]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ vaultwarden_container_labels_base | combine(vaultwarden_container_labels, recursive=True) }}: 'vaultwarden_container_labels' is undefined. 'vaultwarden_container_labels' is undefined. {{ vaultwarden_container_labels_base | combine(vaultwarden_container_labels, recursive=True) }}: 'vaultwarden_container_labels' is undefined. 'vaultwarden_container_labels' is undefined\n\nThe error appears to be in '/home/user/git/project/ansible_collections/famedly/services/roles/vaultwarden/tasks/main.yml': line 76, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Ensure vaultwarden container image is running\n  ^ here\n"}
